### PR TITLE
Hotfix/0.1.2

### DIFF
--- a/Runtime/MotionBlurRenderPass.cs
+++ b/Runtime/MotionBlurRenderPass.cs
@@ -24,7 +24,7 @@ namespace kTools.Motion
         internal MotionBlurRenderPass()
         {
             // Set data
-            renderPassEvent = RenderPassEvent.AfterRenderingPostProcessing;
+            renderPassEvent = RenderPassEvent.BeforeRenderingPostProcessing;
         }
 #endregion
 

--- a/Runtime/MotionVectorRenderPass.cs
+++ b/Runtime/MotionVectorRenderPass.cs
@@ -8,7 +8,7 @@ namespace kTools.Motion
     sealed class MotionVectorRenderPass : ScriptableRenderPass
     {
 #region Fields
-        const string kCameraShader = "Hidden/kMotion/CameraMotionVectors";
+        //const string kCameraShader = "Hidden/kMotion/CameraMotionVectors";
         const string kObjectShader = "Hidden/kMotion/ObjectMotionVectors";
         const string kPreviousViewProjectionMatrix = "_PrevViewProjMatrix";
         const string kMotionVectorTexture = "_MotionVectorTexture";
@@ -21,7 +21,7 @@ namespace kTools.Motion
         };
 
         RenderTargetHandle m_MotionVectorHandle;
-        Material m_CameraMaterial;
+        //Material m_CameraMaterial;
         Material m_ObjectMaterial;
         MotionData m_MotionData;
 #endregion
@@ -39,7 +39,7 @@ namespace kTools.Motion
         {
             // Set data
             m_MotionData = motionData;
-            m_CameraMaterial = new Material(Shader.Find(kCameraShader));
+            //m_CameraMaterial = new Material(Shader.Find(kCameraShader));
             m_ObjectMaterial = new Material(Shader.Find(kObjectShader));
         }
 
@@ -80,7 +80,7 @@ namespace kTools.Motion
                 camera.depthTextureMode |= DepthTextureMode.MotionVectors | DepthTextureMode.Depth;
 
                 // Drawing
-                DrawCameraMotionVectors(context, cmd, camera);
+                //DrawCameraMotionVectors(context, cmd, camera);
                 DrawObjectMotionVectors(context, ref renderingData, cmd, camera);
             }
             ExecuteCommand(context, cmd);
@@ -110,12 +110,12 @@ namespace kTools.Motion
             return drawingSettings;
         }
 
-        void DrawCameraMotionVectors(ScriptableRenderContext context, CommandBuffer cmd, Camera camera)
-        {
-            // Draw fullscreen quad
-            cmd.DrawProcedural(Matrix4x4.identity, m_CameraMaterial, 0, MeshTopology.Triangles, 3, 1);
-            ExecuteCommand(context, cmd);
-        }
+        //void DrawCameraMotionVectors(ScriptableRenderContext context, CommandBuffer cmd, Camera camera)
+        //{
+        //    // Draw fullscreen quad
+        //    cmd.DrawProcedural(Matrix4x4.identity, m_CameraMaterial, 0, MeshTopology.Triangles, 3, 1);
+        //    ExecuteCommand(context, cmd);
+        //}
 
         void DrawObjectMotionVectors(ScriptableRenderContext context, ref RenderingData renderingData, CommandBuffer cmd, Camera camera)
         {


### PR DESCRIPTION
This hot-fix contains 2 fixes:
1) Fix motion blur won't work with camera Post Processing flag is on.
2) Fix wrong motion blur on objects that is attached to the camera or moves with it.